### PR TITLE
Prevent using too much system resources

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ class FileSearchExtension(Extension):
 
     def search(self, query, file_type=None):
         """ Searches for Files using fd command """
-        cmd = ['fd', '-L', '--hidden']
+        cmd = ['timeout', '5s', 'ionice', '-c', '3', 'fd', '--threads', '1', '--hidden']
 
         if file_type == FILE_SEARCH_FILE:
             cmd.append('-t')


### PR DESCRIPTION
Remove unsafe option to follow symlinks, adds a timeout and limits io and cpu usage

See https://github.com/brpaz/ulauncher-file-search/pull/3#issuecomment-450602493

Would remove `--hidden` too, but more due to getting unwanted results than for performance reasons.