### PR TITLE
Automatic fallback to fdfind

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,9 +37,16 @@ class FileSearchExtension(Extension):
         self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
 
     def search(self, query, file_type=None):
+        """ Try with the default fd or the previously successful command """
+        bin_name = 'fd'
+        try:
+            subprocess.check_call([bin_name])
+        except OSError:
+            bin_name = "fdfind" if bin_name == "fd" else "fd"
+
         """ Searches for Files using fd command """
         cmd = [
-            'timeout', '5s', 'ionice', '-c', '3', 'fd', '--threads', '1',
+            'timeout', '5s', 'ionice', '-c', '3', bin_name, '--threads', '1',
             '--hidden'
         ]
 


### PR DESCRIPTION
Fixes (partially) #14 by automatically fallbacking to fdfind if no fd exists.
In my current implementation, the search command will check every single time if fd exists. I'm not experienced with python so I'm refraining from implementing any form of caching for the previously successful result.
In addition, this commit does not give any information to the user if neither fd nor fdfind exists on the system because the current architectural design of the search function does not allow for signifying an executable not found event. Again, I'm refraining from making any architectural changes.