### PR TITLE
Fix terminal launch and add kitty terminal

### DIFF
--- a/main.py
+++ b/main.py
@@ -115,8 +115,8 @@ class FileSearchExtension(Extension):
         if terminal_emulator in [
                 'gnome-terminal', 'terminator', 'tilix', 'xfce-terminal'
         ]:
-            return RunScriptAction(terminal_emulator,
-                                   ['--working-directory', path])
+            return RunScriptAction(f'{terminal_emulator} $@',
+                                   ' '.join(['--working-directory', path]))
 
         return DoNothingAction()
 

--- a/main.py
+++ b/main.py
@@ -27,6 +27,14 @@ FILE_SEARCH_DIRECTORY = 'DIR'
 
 FILE_SEARCH_FILE = 'FILE'
 
+TERMINAL_PARAMS = {
+    'gnome-terminal': ['--working-directory'],
+    'terminator': ['--working-directory'],
+    'tilix': ['--working-directory'],
+    'xfce-terminal': ['--working-directory'],
+    'kitty': ['--directory']
+}
+
 
 class FileSearchExtension(Extension):
     """ Main Extension Class  """
@@ -112,11 +120,9 @@ class FileSearchExtension(Extension):
         terminal_emulator = self.preferences['terminal_emulator']
 
         # some terminals might work differently. This is already prepared for that.
-        if terminal_emulator in [
-                'gnome-terminal', 'terminator', 'tilix', 'xfce-terminal'
-        ]:
+        if terminal_emulator in TERMINAL_PARAMS:
             return RunScriptAction(f'{terminal_emulator} $@',
-                                   ' '.join(['--working-directory', path]))
+                                   ' '.join([*TERMINAL_PARAMS[terminal_emulator], path]))
 
         return DoNothingAction()
 

--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,7 @@
       "name": "Terminal Emulator",
       "description": "Sets the terminal emulator to open directories directly in the terminal",
       "default_value": "gnome-terminal",
-      "options": ["gnome-terminal", "tilix", "terminator", "xfce-terminal"]
+      "options": ["gnome-terminal", "tilix", "terminator", "xfce-terminal", "kitty"]
     },
     {
       "id": "base_dir",


### PR DESCRIPTION
Terminal launch fails to open in the chosen directory at least on Ulauncher v5.9.0 API v2.0.0